### PR TITLE
express-session を v1.17.3 にアップデート

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "express-session": "1.17.3",
     "helmet": "^1.1.0",
     "http-errors": "~1.6.2",
-    "jquery": "^3.3.1",
+    "jquery": "3.6.0",
     "morgan": "~1.9.0",
     "passport": "0.6.0",
     "passport-twitter": "^1.0.4",


### PR DESCRIPTION
express-session を v1.17.3 にアップデートしました。
（ https://github.com/nnn-training/change-repo-contents-all を使って作成しました）